### PR TITLE
Fix typo on Booster download screen

### DIFF
--- a/booster/src/fs/downloading.shtml
+++ b/booster/src/fs/downloading.shtml
@@ -60,7 +60,7 @@
     <div>
       <br />
       <p>
-        The app is now being downloaded to the device. This process may take a 10 to 20 seconds.
+        The app is now being downloaded to the device. This process may take 10 to 20 seconds.
       </p>
       <p>
         When the download is complete, this page will automatically redirect to the home page of the Booster app, where


### PR DESCRIPTION
## Summary
- drop the stray "a" in "may take 10 to 20 seconds"
- ensure the HTML file ends with a newline (matches emailed patch)
